### PR TITLE
Fixed players "Losing" when they havent lost

### DIFF
--- a/components/MultiplayerCanvas.js
+++ b/components/MultiplayerCanvas.js
@@ -462,19 +462,17 @@ const socketInitializer = async () => {
         socket.on('playerStateUpdate', PLAYERENDDATA => {
             if (gameStateOuter == "Playing")
             {
-                if (PLAYERENDDATA.id == myVoxel.id)
-                {
-                    delete voxelList[ID]; 
-                    //Get the first random
-                    myVoxel = voxelList[Object.keys(voxelList)[1]]
-                }
-                if (PLAYERENDDATA.outcome == "won")
+                
+                if (PLAYERENDDATA.outcome == "won" && PLAYERENDDATA.id == myVoxel.id)
                 {
                     setPlayerState("Won");
                     playerStateOuter = "Won";
                 }
-                else if (PLAYERENDDATA.outcome == "lost")
+                else if (PLAYERENDDATA.outcome == "lost" && PLAYERENDDATA.id == myVoxel.id)
                 {
+                    delete voxelList[ID]; 
+                    //Get the first random
+                    myVoxel = voxelList[Object.keys(voxelList)[1]]
                     setPlayerState("Lost");
                     playerStateOuter = "Lost";
                 }


### PR DESCRIPTION
ID Check on the client side listener to 'playerStateUpdate' was written in the wrong place. ID was not being checked when players lost. Fixes 